### PR TITLE
Add projects & sort by audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,26 +11,28 @@ We call on Microsoft to end is relationship with ICE and any federal agencies en
 
 Signed,
 
+-  Lea Verou [@leaverou](https://github.com/leaverou) (MIT, CSSWG, Prism, Mavo, Dabblet)
+-  Thomas Fuchs [@madrobby](https://github.com/madrobby) (Zepto, Script.aculo.us, Ruby on Rails)
+-  Laurie Voss [@seldo](https://github.com/seldo) (npm, LGBTQ.technology)
+-  Jamie Kyle [@jamiebuilds](https://github.com/jamiebuilds) (Babel, Yarn, Flow, Parcel, Marionette, Lerna)
+-  Rick Waldron [@rwaldron](https://github.com/rwaldron) (Ecma/TC39, Johnny-Five)
 -  Daniel Sieradski [@selfagency](https://github.com/selfagency)
 -  Nicholas Sahler [@nicksahler](https://github.com/nicksahler)
 -  Gavin Morgan [@quavmo](https://github.com/quavmo)
 -  Abram Stern [@aphid](https://github.com/aphid)
 -  Libby Horacek [@emhoracek](https://github.com/emhoracek)
 -  Jeremy Low [@jeremylow](https://github.com/jeremylow)
--  Rick Waldron [@rwaldron](https://github.com/rwaldron)
 -  Jacob Beard [@jbeard4](https://github.com/jbeard4)
 -  Joshua Cook [@joshuacook](https://github.com/joshuacook)
--  Lea Verou [@leaverou](https://github.com/leaverou)
 -  Tomas Lycken [@tlycken](https://github.com/tlycken) 
 -  Tobi Schäfer [@p3k](https://github.com/p3k)
 -  Mijndert Stuij [@mijndert](https://github.com/mijndert) 
 -  John Hann [@unscriptable](https://github.com/unscriptable)
 -  Thijs van der Vossen [@fingertips](https://github.com/Fingertips)
 -  Marc Hinse [@MadeMyDay](https://github.com/MadeMyDay)
--  Thomas Fuchs [@madrobby](https://github.com/madrobby)
 -  Frank Bültge [@bueltge](https://github.com/bueltge)
--  Laurie Voss [@seldo](https://github.com/seldo)
--  Jamie Kyle [@jamiebuilds](https://github.com/jamiebuilds)
 -  Bernard Lin [@bernard-lin](https://github.com/bernard-lin)
+
+> **Notice:** Although various projects and organizations may be listed next to signees, these signatures do not necessarily reflect the views of anyone except the signees.
 
 **To add your name or recommend alterations to this text, please submit a PR!**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Signed,
 
 -  Lea Verou [@leaverou](https://github.com/leaverou) (MIT, W3C CSS Working Group, Prism, Mavo, Dabblet)
 -  Thomas Fuchs [@madrobby](https://github.com/madrobby) (Zepto, Script.aculo.us, Ruby on Rails)
--  Laurie Voss [@seldo](https://github.com/seldo) (npm, LGBTQ.technology)
+-  Laurie Voss [@seldo](https://github.com/seldo) (LGBTQ.technology)
 -  Jamie Kyle [@jamiebuilds](https://github.com/jamiebuilds) (Babel, Yarn, Flow, Parcel, Marionette, Lerna)
 -  Rick Waldron [@rwaldron](https://github.com/rwaldron) (Ecma/TC39, Johnny-Five)
 -  Daniel Sieradski [@selfagency](https://github.com/selfagency)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ We call on Microsoft to end is relationship with ICE and any federal agencies en
 
 Signed,
 
--  Lea Verou [@leaverou](https://github.com/leaverou) (MIT, CSSWG, Prism, Mavo, Dabblet)
+-  Lea Verou [@leaverou](https://github.com/leaverou) (MIT, W3C CSS Working Group, Prism, Mavo, Dabblet)
 -  Thomas Fuchs [@madrobby](https://github.com/madrobby) (Zepto, Script.aculo.us, Ruby on Rails)
 -  Laurie Voss [@seldo](https://github.com/seldo) (npm, LGBTQ.technology)
 -  Jamie Kyle [@jamiebuilds](https://github.com/jamiebuilds) (Babel, Yarn, Flow, Parcel, Marionette, Lerna)


### PR DESCRIPTION
While every signature is hugely important, in order to ensure the signatures have the maximum impact, I've gone ahead and listed prominent projects/organizations that some of the signees either publicly identify being part of or are the maintainer/creator of.

I've also placed signees with large audiences at the top (I sorted them by number of Twitter followers).

I also added a note at the bottom that states that signatures belong to solely the signees and do not necessarily reflect the projects/organizations that may be listed next to them.

cc @leaverou @madrobby @seldo @jamiebuilds @rwaldron are you all okay with this?